### PR TITLE
Add Control Flow Guard

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -25,6 +25,7 @@ if(MSVC AND CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 if(MSVC AND CMAKE_BUILD_TYPE MATCHES Release)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /guard:cf")
     add_link_options("/OPT:REF")
 endif()
 


### PR DESCRIPTION
Enable control flow guard when building with msvc as nironcompress.dll is reporting [BA2008](https://github.com/microsoft/binskim/blob/main/docs/BinSkimRules.md#rule-BA2008EnableControlFlowGuard) from BinSkim.

Verified that after this change that binskim no longer reports BA2008.

More details for /guard command can be found [here](https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-control-flow-guard?view=msvc-170).